### PR TITLE
Fix: Send encoding email to many managers

### DIFF
--- a/pod/video/encode.py
+++ b/pod/video/encode.py
@@ -1203,7 +1203,11 @@ def send_email_encoding(video_to_encode):
     ):
         bcc_email = []
         video_estab = video_to_encode.owner.owner.establishment.lower()
-        bcc_email.append(dict(MANAGERS)[video_estab])
+        manager = dict(MANAGERS)[video_estab]
+        if type(manager) in (list, tuple):
+            bcc_email = manager
+        elif type(manager) == str:
+            bcc_email.append(manager)
         msg = EmailMultiAlternatives(
             subject,
             message,


### PR DESCRIPTION
@ptitloup Une petite correction du code, permettant d'avoir une ou plusieurs managers d'un établissement et que ce(s) puissent recevoir le mail de fin d'encodage d'une vidéo appartenant à leur établissement.